### PR TITLE
Allows more flexible scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,5 +76,24 @@ In [10]: rest.sound
 Out[10]: <PyHatchBabyRestSound.noise: 3>
 ```
 
+#### NOTE: Using PyHatchBabyRestAsync from async code
+The constructor, by default, executes directly against the event loop. This doesn't work if it is executed within an already running coroutine. To construct the client, all async calls must be done outside of the constructor.
+
+This has been all wrapped up in a function for ease of use.
+
+```python3
+import asyncio
+
+from pyhatchbabyrest import connect_async
+
+
+async def main():
+    rest = await connect_async()
+    await rest.power_on()
+
+
+rest = asyncio.run(main())
+```
+
 ## Credits
 Huge thanks to @Marcus-L for their repo at [GitHub - Marcus-L/m4rcus.HatchBaby.Rest: Control Hatch Baby Rest devices using Bluetooth LE](https://github.com/Marcus-L/m4rcus.HatchBaby.Rest) which did all the hard work of finding the right characteristics, commands, etc.

--- a/pyhatchbabyrest/__init__.py
+++ b/pyhatchbabyrest/__init__.py
@@ -1,4 +1,5 @@
 from .pyhatchbabyrest import PyHatchBabyRest  # noqa: F401
 from .pyhatchbabyrestasync import PyHatchBabyRestAsync  # noqa: F401
+from .pyhatchbabyrestasync import connect as connect_async  # noqa: F401
 
 name = "pyhatchbabyrest"

--- a/pyhatchbabyrest/constants.py
+++ b/pyhatchbabyrest/constants.py
@@ -3,6 +3,7 @@ from enum import IntEnum
 COLOR_GRADIENT = (254, 254, 254)  # setting this color turns on Gradient mode
 CHAR_TX = "02240002-5efd-47eb-9c1a-de53f7a2b232"
 CHAR_FEEDBACK = "02260002-5efd-47eb-9c1a-de53f7a2b232"
+BT_MANUFACTURER_ID = 1076
 
 
 class PyHatchBabyRestSound(IntEnum):


### PR DESCRIPTION
This patch uses the BleakScanner interface to simplify the scanning as
well as provide more means of connecting. With an address, a BLEDevice,
or with a user provided scanner.

This change will allow me to implement a Home Assistant integration
using [Bluetooth
discovery](https://developers.home-assistant.io/docs/network_discovery/#best-practices-for-library-authors).

Other changes: `black`